### PR TITLE
Fix Ray init for modern versions

### DIFF
--- a/DeepCFR/__init__.py
+++ b/DeepCFR/__init__.py
@@ -2,3 +2,36 @@
 
 __all__ = []
 __version__ = "0.1.0"
+
+# ---------------------------------------------------------------------------
+# Compatibility patch for Ray >=2.0
+# ---------------------------------------------------------------------------
+#
+# The original PokerRL `MaybeRay` wrapper passed a `redis_max_memory` argument
+# when initialising Ray.  This option was removed from newer Ray releases,
+# causing `ray.init` to raise `RuntimeError: Unknown keyword argument(s)` when
+# running Deep-CFR with modern Ray versions.  Here we monkey‑patch the
+# `init_local` method to drop the obsolete parameter and keep the existing
+# behaviour of limiting the object store memory.
+#
+# This code executes on import so the patched behaviour is applied before the
+# framework initialises Ray.
+try:  # pragma: no cover - best effort patching
+    import psutil
+    import ray
+    from PokerRL.rl.MaybeRay import MaybeRay
+
+    def _init_local(self):
+        if self.runs_distributed:
+            ray.init(
+                object_store_memory=min(
+                    2 * (10 ** 10), int(psutil.virtual_memory().total * 0.4)
+                ),
+            )
+
+    MaybeRay.init_local = _init_local
+except Exception:  # noqa: S110
+    # Dependencies are optional at import time; if they are missing we simply
+    # skip the patch and rely on the original implementation.
+    pass
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==2.3.2
 psutil==7.0.0
-ray==2.48.0
+ray>=2.0
 torch==2.8.0
 PokerRL @ git+https://github.com/theGholland/PokerRL-2025.git
 tensorboard==2.17.0


### PR DESCRIPTION
## Summary
- monkey patch PokerRL's `MaybeRay` to drop removed `redis_max_memory` argument
- require Ray 2.x in `requirements.txt`

## Testing
- `python - <<'PY'
from PokerRL.rl.MaybeRay import MaybeRay
mr = MaybeRay(runs_distributed=True)
mr.init_local()
print('init_local succeeded')
PY`
- `python paper_experiment_sdcfr_vs_deepcfr_h2h.py --iterations 1 --local_mode True --num_players 2 --eval_every 1` (fails: `TypeError: cannot pickle '_thread.lock' object`)


------
https://chatgpt.com/codex/tasks/task_e_689793f13fa88330b69fc46dbcfea64a