### PR TITLE
Fix TrainingProfile pickling to keep tensorboard logging

### DIFF
--- a/DeepCFR/TrainingProfile.py
+++ b/DeepCFR/TrainingProfile.py
@@ -246,3 +246,12 @@ class TrainingProfile(TrainingProfileBase):
 
         assert isinstance(device_parameter_server, str), "Please pass a string (either 'cpu' or 'cuda')!"
         self.device_parameter_server = torch.device(device_parameter_server)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["tb_writer"] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.tb_writer = SummaryWriter(log_dir=self.path_log_storage) if self.log_verbose else None


### PR DESCRIPTION
## Summary
- ensure TrainingProfile reinitialises its tensorboard writer when unpickled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897996233088330a6b9925e3bd99f9e