### PR TITLE
Enable automatic CUDA resource detection for Ray

### DIFF
--- a/DeepCFR/__init__.py
+++ b/DeepCFR/__init__.py
@@ -19,15 +19,29 @@ __version__ = "0.1.0"
 try:  # pragma: no cover - best effort patching
     import psutil
     import ray
+    import torch
     from PokerRL.rl.MaybeRay import MaybeRay
 
     def _init_local(self):
         if self.runs_distributed:
-            ray.init(
-                object_store_memory=min(
+            # Auto-detect available resources so Ray can schedule workers on both
+            # CPU and GPU without additional configuration.  This prevents Ray
+            # from crashing when CUDA is present but resources have not been
+            # declared explicitly.
+            ray_init_kwargs = {
+                "object_store_memory": min(
                     2 * (10 ** 10), int(psutil.virtual_memory().total * 0.4)
                 ),
-            )
+                "num_cpus": psutil.cpu_count() or 1,
+            }
+
+            try:
+                if torch.cuda.is_available():
+                    ray_init_kwargs["num_gpus"] = torch.cuda.device_count()
+            except Exception:  # pragma: no cover - best effort GPU detection
+                pass
+
+            ray.init(**ray_init_kwargs)
 
     MaybeRay.init_local = _init_local
 except Exception:  # noqa: S110


### PR DESCRIPTION
## Summary
- ensure Ray initialization automatically detects CPU/GPU resources via `psutil` and `torch`
- prevent crashes when CUDA resources are present by passing detected counts to `ray.init`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a6213e3483308d3ab59006da7e60