### PR TITLE
Use Ray options to manage actor resources

### DIFF
--- a/DeepCFR/workers/chief/dist.py
+++ b/DeepCFR/workers/chief/dist.py
@@ -3,7 +3,7 @@ import ray
 from DeepCFR.workers.chief.local import Chief as _LocalChief
 
 
-@ray.remote(num_cpus=1)
+@ray.remote
 class Chief(_LocalChief):
 
     def __init__(self, t_prof):

--- a/DeepCFR/workers/la/dist.py
+++ b/DeepCFR/workers/la/dist.py
@@ -1,10 +1,9 @@
 import ray
-import torch
 
 from DeepCFR.workers.la.local import LearnerActor as LocalLearnerActor
 
 
-@ray.remote(num_cpus=1, num_gpus=1 if torch.cuda.is_available() else 0)
+@ray.remote
 class LearnerActor(LocalLearnerActor):
 
     def __init__(self, t_prof, worker_id, chief_handle):

--- a/DeepCFR/workers/ps/dist.py
+++ b/DeepCFR/workers/ps/dist.py
@@ -1,10 +1,9 @@
 import ray
-import torch
 
 from DeepCFR.workers.ps.local import ParameterServer as _LocalParameterServer
 
 
-@ray.remote(num_cpus=1, num_gpus=1 if torch.cuda.is_available() else 0)
+@ray.remote
 class ParameterServer(_LocalParameterServer):
 
     def __init__(self, t_prof, owner, chief_handle):


### PR DESCRIPTION
## Summary
- Let distributed chief, learner and parameter server actors rely on Ray's resource options so fractional CPU/GPU allocations can be applied.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a19c914808330b325fa44f5f62f5d