### PR TITLE
Disable Ray dashboard to support minimal installation

### DIFF
--- a/DeepCFR/__init__.py
+++ b/DeepCFR/__init__.py
@@ -33,7 +33,7 @@ try:  # pragma: no cover - best effort patching
                     2 * (10 ** 10), int(psutil.virtual_memory().total * 0.4)
                 ),
                 "num_cpus": psutil.cpu_count() or 1,
-                "include_dashboard": True,
+                "include_dashboard": False,
             }
 
             try:


### PR DESCRIPTION
## Summary
- prevent Ray from starting the dashboard when running distributed training so minimal `ray` installs can initialize without `Cannot include dashboard` errors

## Testing
- `python -m py_compile DeepCFR/__init__.py`
- `python paper_experiment_sdcfr_vs_deepcfr_h2h.py --iterations 1 --local_mode True --num_players 2 --eval_every 1` *(fails: Task was killed due to the node running low on memory)*

------
https://chatgpt.com/codex/tasks/task_e_689a2bcde22c83308b19ceed8b23bdaf