### PR TITLE
Enable Ray dashboard and install full Ray package

### DIFF
--- a/DeepCFR/__init__.py
+++ b/DeepCFR/__init__.py
@@ -33,7 +33,12 @@ try:  # pragma: no cover - best effort patching
                     2 * (10 ** 10), int(psutil.virtual_memory().total * 0.4)
                 ),
                 "num_cpus": psutil.cpu_count() or 1,
-                "include_dashboard": False,
+                # Enable Ray's web dashboard so users can monitor resource usage
+                # and task progress at http://localhost:8265.  We bind to
+                # ``0.0.0.0`` so the dashboard is reachable when running on a
+                # remote machine.
+                "include_dashboard": True,
+                "dashboard_host": "0.0.0.0",
             }
 
             try:

--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ To monitor training progress, launch TensorBoard in a separate terminal with
 tensorboard --logdir ~/poker_ai_data/logs
 ```
 
-Then open `http://localhost:6006` in your browser to view logs. To run Deep CFR or SD-CFR with custom hyperparameters in
-any Poker game supported by PokerRL-2025, build a script similar to `DeepCFR/leduc_example.py`. Run-scripts define
+Then open `http://localhost:6006` in your browser to view logs.  Ray's own
+dashboard is started automatically and exposes cluster metrics at
+`http://localhost:8265` (replace `localhost` with your machine's IP if running
+remotely).  To run Deep CFR or SD-CFR with custom hyperparameters in any Poker
+game supported by PokerRL-2025, build a script similar to `DeepCFR/leduc_example.py`. Run-scripts define
 the hyperparameters, the game to be played, and the evaluation metrics. Here is a very minimalistic example showing a
 few of the available settings:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {file = "LICENSE"}
 dependencies = [
     "numpy==2.3.2",
     "psutil==7.0.0",
-    "ray==2.48.0",
+    "ray[default]==2.48.0",
     "torch==2.8.0",
     "PokerRL @ git+https://github.com/theGholland/PokerRL-2025.git",
     "tensorboard==2.20.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==2.3.2
 psutil==7.0.0
-ray>=2.0
+ray[default]>=2.0
 torch==2.8.0
 PokerRL @ git+https://github.com/theGholland/PokerRL-2025.git
 tensorboard==2.20.0


### PR DESCRIPTION
## Summary
- enable Ray dashboard when running in distributed mode and expose it on all interfaces
- document that the dashboard is available at port 8265
- depend on `ray[default]` so the dashboard packages are installed

## Testing
- `pytest`
- `python - <<'PY'
import DeepCFR
import ray
ray.shutdown()
ctx = ray.init(include_dashboard=True, dashboard_host='0.0.0.0')
print('dashboard_url:', ctx.dashboard_url)
ray.shutdown()
PY`


------
https://chatgpt.com/codex/tasks/task_e_689a3030680883309275fe2c43568e10