### PR TITLE
Pin full Ray dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==2.3.2
 psutil==7.0.0
-ray[default]>=2.0
+ray[default]==2.48.0
 torch==2.8.0
 PokerRL @ git+https://github.com/theGholland/PokerRL-2025.git
 tensorboard==2.20.0


### PR DESCRIPTION
## Summary
- pin `ray[default]` in requirements.txt to ensure full Ray install with dashboard

## Testing
- `python -m pip check`


------
https://chatgpt.com/codex/tasks/task_e_689a344247d083308a9e643ca0a0c179