### PR TITLE
Auto-tune batch sizes based on free RAM

### DIFF
--- a/DeepCFR/TrainingProfile.py
+++ b/DeepCFR/TrainingProfile.py
@@ -15,6 +15,7 @@ from PokerRL.rl.neural.DuelingQNet import DuelingQArgs
 from DeepCFR.EvalAgentDeepCFR import EvalAgentDeepCFR
 from DeepCFR.workers.la.AdvWrapper import AdvTrainingArgs
 from DeepCFR.workers.la.AvrgWrapper import AvrgTrainingArgs
+from utils.memory import estimate_batch_size
 
 
 def _resolve_device(dev):
@@ -80,7 +81,7 @@ class TrainingProfile(TrainingProfileBase):
                  n_cards_state_units_adv=96,
                  n_merge_and_table_layer_units_adv=32,
                  n_units_final_adv=64,
-                 mini_batch_size_adv=4096,
+                 mini_batch_size_adv=None,
                  n_mini_batches_per_la_per_update_adv=1,
                  optimizer_adv="adam",
                  loss_adv="weighted_mse",
@@ -103,7 +104,7 @@ class TrainingProfile(TrainingProfileBase):
                  n_cards_state_units_avrg=96,
                  n_merge_and_table_layer_units_avrg=32,
                  n_units_final_avrg=64,
-                 mini_batch_size_avrg=4096,
+                 mini_batch_size_avrg=None,
                  n_mini_batches_per_la_per_update_avrg=1,
                  loss_avrg="weighted_mse",
                  optimizer_avrg="adam",
@@ -129,6 +130,13 @@ class TrainingProfile(TrainingProfileBase):
         device_inference = _resolve_device(device_inference)
         device_training = _resolve_device(device_training)
         device_parameter_server = _resolve_device(device_parameter_server)
+
+        if mini_batch_size_adv is None or mini_batch_size_avrg is None:
+            est = estimate_batch_size()
+            if mini_batch_size_adv is None:
+                mini_batch_size_adv = est
+            if mini_batch_size_avrg is None:
+                mini_batch_size_avrg = est
 
         if nn_type == "recurrent":
             from PokerRL.rl.neural.MainPokerModuleRNN import MPMArgsRNN
@@ -231,7 +239,7 @@ class TrainingProfile(TrainingProfileBase):
                 "lbr": lbr_args,
                 "rlbr": rl_br_args,
                 "h2h": h2h_args,
-            }
+            } 
         )
 
         self.nn_type = nn_type
@@ -242,6 +250,9 @@ class TrainingProfile(TrainingProfileBase):
         self.n_actions_traverser_samples = n_actions_traverser_samples
 
         self.tb_writer = SummaryWriter(log_dir=self.path_log_storage)
+
+        self.mini_batch_size_adv = mini_batch_size_adv
+        self.mini_batch_size_avrg = mini_batch_size_avrg
 
         # SINGLE
         self.export_each_net = export_each_net

--- a/DeepCFR/workers/la/AdvWrapper.py
+++ b/DeepCFR/workers/la/AdvWrapper.py
@@ -15,6 +15,7 @@ class AdvWrapper(_NetWrapperBase):
             owner=owner,
             device=device
         )
+        self._batch_size = adv_training_args.batch_size
 
     def get_advantages(self, pub_obses, range_idxs, legal_action_mask):
         self._net.eval()
@@ -27,7 +28,7 @@ class AdvWrapper(_NetWrapperBase):
         batch_legal_action_masks, \
         batch_adv, \
         batch_loss_weight, \
-            = buffer.sample(device=self.device, batch_size=self._args.batch_size)
+            = buffer.sample(device=self.device, batch_size=self._batch_size)
 
         # [batch_size, n_actions]
         adv_pred = self._net(pub_obses=batch_pub_obs,

--- a/DeepCFR/workers/la/AvrgWrapper.py
+++ b/DeepCFR/workers/la/AvrgWrapper.py
@@ -18,6 +18,7 @@ class AvrgWrapper(_NetWrapperBase):
             device=device
         )
         self._all_range_idxs = torch.arange(self._env_bldr.rules.RANGE_SIZE, device=self.device, dtype=torch.long)
+        self._batch_size = avrg_training_args.batch_size
 
     def get_a_probs(self, pub_obses, range_idxs, legal_actions_lists):
         """
@@ -60,7 +61,7 @@ class AvrgWrapper(_NetWrapperBase):
         batch_legal_action_masks, \
         batch_a_probs, \
         batch_loss_weight, \
-            = buffer.sample(device=self.device, batch_size=self._args.batch_size)
+            = buffer.sample(device=self.device, batch_size=self._batch_size)
 
         # [batch_size, n_actions]
         strat_pred = self._net(pub_obses=batch_pub_obs,

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,3 @@
+from .memory import estimate_batch_size, get_available_ram
+
+__all__ = ["estimate_batch_size", "get_available_ram"]

--- a/utils/memory.py
+++ b/utils/memory.py
@@ -1,0 +1,19 @@
+import psutil
+
+
+def get_available_ram() -> int:
+    """Return available RAM in bytes."""
+    return psutil.virtual_memory().available
+
+
+def estimate_batch_size(min_batch_size: int = 512, max_batch_size: int = 16384) -> int:
+    """Estimate a batch size from available RAM.
+
+    The estimate scales linearly with available gigabytes (1GB -> 1024 samples)
+    and is clamped between ``min_batch_size`` and ``max_batch_size``.
+    """
+    avail_gb = get_available_ram() / (1024 ** 3)
+    est = int(avail_gb * 1024)
+    if max_batch_size is not None:
+        est = min(est, max_batch_size)
+    return max(min_batch_size, est)


### PR DESCRIPTION
## Summary
- add utility to estimate available RAM and derive a reasonable batch size
- default `mini_batch_size_adv` and `mini_batch_size_avrg` now scale with available memory
- forward computed batch sizes to AdvWrapper and AvrgWrapper for training

## Testing
- `python -m py_compile utils/memory.py utils/__init__.py DeepCFR/TrainingProfile.py DeepCFR/workers/la/AdvWrapper.py DeepCFR/workers/la/AvrgWrapper.py`


------
https://chatgpt.com/codex/tasks/task_e_689a4be6820083309325bff8299a184f