### PR TITLE
Refactor logging to timestamped tensorboard directories

### DIFF
--- a/DeepCFR/TrainingProfile.py
+++ b/DeepCFR/TrainingProfile.py
@@ -234,7 +234,7 @@ class TrainingProfile(TrainingProfileBase):
                 ),
                 "lbr": lbr_args,
                 "rlbr": rl_br_args,
-            "h2h": h2h_args,
+                "h2h": h2h_args,
             }
         )
 

--- a/DeepCFR/TrainingProfile.py
+++ b/DeepCFR/TrainingProfile.py
@@ -2,6 +2,10 @@
 
 
 import copy
+import os
+import re
+import shutil
+from datetime import datetime
 
 import torch
 from torch.utils.tensorboard import SummaryWriter
@@ -230,9 +234,16 @@ class TrainingProfile(TrainingProfileBase):
                 ),
                 "lbr": lbr_args,
                 "rlbr": rl_br_args,
-                "h2h": h2h_args,
+            "h2h": h2h_args,
             }
         )
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        sanitized_name = re.sub(r"[^\w.-]", "_", str(self.name))
+        self.path_log_storage = os.path.join(self._data_path, "tensorboard", sanitized_name, timestamp)
+        if os.path.exists(self.path_log_storage):
+            shutil.rmtree(self.path_log_storage)
+        os.makedirs(self.path_log_storage, exist_ok=True)
 
         self.nn_type = nn_type
         self.online = online

--- a/DeepCFR/workers/driver/_HighLevelAlgo.py
+++ b/DeepCFR/workers/driver/_HighLevelAlgo.py
@@ -82,11 +82,13 @@ class HighLevelAlgo(_HighLevelAlgoBase):
 
         # For logging the loss to see convergence in Tensorboard
         if self._t_prof.log_verbose:
-            exp_loss_each_p = [self._ray.remote(self._chief_handle.create_experiment,
-                                                self._t_prof.name + "_ADV_Loss_P" + str(p) + "_I" + str(
-                                                    cfr_iter))
-                               for p in range(self._t_prof.n_seats)
-                               ]
+            exp_loss_each_p = [
+                self._ray.remote(
+                    self._chief_handle.create_experiment,
+                    f"P{p}/Adv_Loss_I{cfr_iter}",
+                )
+                for p in range(self._t_prof.n_seats)
+            ]
 
         self._ray.wait([
             self._ray.remote(self._ps_handles[p_id].reset_adv_net, cfr_iter)
@@ -244,11 +246,13 @@ class HighLevelAlgo(_HighLevelAlgoBase):
 
         # For logging the loss to see convergence in Tensorboard
         if self._t_prof.log_verbose:
-            exp_loss_each_p = [self._ray.remote(self._chief_handle.create_experiment,
-                                                self._t_prof.name + "_AverageNet_Loss_P" + str(p) + "_I" + str(
-                                                    cfr_iter))
-                               for p in range(self._t_prof.n_seats)
-                               ]
+            exp_loss_each_p = [
+                self._ray.remote(
+                    self._chief_handle.create_experiment,
+                    f"P{p}/Avrg_Loss_I{cfr_iter}",
+                )
+                for p in range(self._t_prof.n_seats)
+            ]
 
         self._ray.wait([self._ray.remote(self._ps_handles[p_id].reset_avrg_net)])
         self._update_leaner_actors(update_avrg_for_plyrs=[p_id])

--- a/DeepCFR/workers/la/local.py
+++ b/DeepCFR/workers/la/local.py
@@ -105,22 +105,26 @@ class LearnerActor(WorkerBase):
         if self._t_prof.log_verbose:
             self._exp_perf = self._ray.get(
                 self._ray.remote(self._chief_handle.create_experiment,
-                                 self._t_prof.name + "_LA" + str(worker_id) + "_Perf"))
+                                 f"LA{worker_id}/Perf"))
             self._exp_mem_usage = self._ray.get(
                 self._ray.remote(self._chief_handle.create_experiment,
-                                 self._t_prof.name + "_LA" + str(worker_id) + "_Memory_Usage"))
+                                 f"LA{worker_id}/Memory_Usage"))
             self._exps_adv_buffer_size = self._ray.get(
                 [
-                    self._ray.remote(self._chief_handle.create_experiment,
-                                     self._t_prof.name + "_LA" + str(worker_id) + "_P" + str(p) + "_ADV_BufSize")
+                    self._ray.remote(
+                        self._chief_handle.create_experiment,
+                        f"LA{worker_id}/P{p}/ADV_BufSize",
+                    )
                     for p in range(self._t_prof.n_seats)
                 ]
             )
             if self._AVRG:
                 self._exps_avrg_buffer_size = self._ray.get(
                     [
-                        self._ray.remote(self._chief_handle.create_experiment,
-                                         self._t_prof.name + "_LA" + str(worker_id) + "_P" + str(p) + "_AVRG_BufSize")
+                        self._ray.remote(
+                            self._chief_handle.create_experiment,
+                            f"LA{worker_id}/P{p}/AVRG_BufSize",
+                        )
                         for p in range(self._t_prof.n_seats)
                     ]
                 )

--- a/DeepCFR/workers/ps/local.py
+++ b/DeepCFR/workers/ps/local.py
@@ -25,7 +25,7 @@ class ParameterServer(ParameterServerBase):
         if self._t_prof.log_verbose:
             self._exp_mem_usage = self._ray.get(
                 self._ray.remote(self._chief_handle.create_experiment,
-                                 self._t_prof.name + "_PS" + str(owner) + "_Memory_Usage"))
+                                 f"PS{owner}/Memory_Usage"))
 
         self._AVRG = EvalAgentDeepCFR.EVAL_MODE_AVRG_NET in self._t_prof.eval_modes_of_algo
         self._SINGLE = EvalAgentDeepCFR.EVAL_MODE_SINGLE in self._t_prof.eval_modes_of_algo


### PR DESCRIPTION
## Summary
- route TensorBoard logs to timestamped directories under each experiment
- sanitize experiment names and create SummaryWriter instances per run
- simplify logging calls to use concise identifiers like `LA0/Perf`

## Testing
- `python -m py_compile DeepCFR/TrainingProfile.py DeepCFR/workers/chief/local.py DeepCFR/workers/ps/local.py DeepCFR/workers/driver/_HighLevelAlgo.py DeepCFR/workers/la/local.py`


------
https://chatgpt.com/codex/tasks/task_e_689a4c5806c08330878315c1865d37d0