### PR TITLE
Enable default TensorBoard logging

### DIFF
--- a/DeepCFR/TrainingProfile.py
+++ b/DeepCFR/TrainingProfile.py
@@ -260,7 +260,7 @@ class TrainingProfile(TrainingProfileBase):
         self.sampler = sampler
         self.n_actions_traverser_samples = n_actions_traverser_samples
 
-        self.tb_writer = SummaryWriter(log_dir=self.path_log_storage)
+        self.tb_writer = SummaryWriter(log_dir=self.path_log_storage) if self.log_verbose else None
 
         self.mini_batch_size_adv = mini_batch_size_adv
         self.mini_batch_size_avrg = mini_batch_size_avrg

--- a/paper_experiment_bigleduc_exploitability.py
+++ b/paper_experiment_bigleduc_exploitability.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
                                          h2h_args=H2HArgs(
                                              n_hands=500000,
                                          ),
-                                         log_verbose=False,
+                                         log_verbose=True,
                                          device_training=args.device_training,
                                          device_parameter_server=args.device_parameter_server,
                                          device_inference=args.device_inference,

--- a/paper_experiment_leduc_example_buf_10.py
+++ b/paper_experiment_leduc_example_buf_10.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
                                          ),
 
                                          DISTRIBUTED=False,
-                                         log_verbose=False,
+                                         log_verbose=True,
                                          device_training=args.device_training,
                                          device_parameter_server=args.device_parameter_server,
                                          device_inference=args.device_inference,

--- a/paper_experiment_leduc_example_buf_100.py
+++ b/paper_experiment_leduc_example_buf_100.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
                                          ),
 
                                          DISTRIBUTED=False,
-                                         log_verbose=False,
+                                         log_verbose=True,
                                          device_training=args.device_training,
                                          device_parameter_server=args.device_parameter_server,
                                          device_inference=args.device_inference,

--- a/paper_experiment_leduc_example_buf_1000.py
+++ b/paper_experiment_leduc_example_buf_1000.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
                                          ),
 
                                          DISTRIBUTED=False,
-                                         log_verbose=False,
+                                         log_verbose=True,
                                          device_training=args.device_training,
                                          device_parameter_server=args.device_parameter_server,
                                          device_inference=args.device_inference,

--- a/paper_experiment_leduc_example_buf_50.py
+++ b/paper_experiment_leduc_example_buf_50.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
                                          ),
 
                                          DISTRIBUTED=False,
-                                         log_verbose=False,
+                                         log_verbose=True,
                                          device_training=args.device_training,
                                          device_parameter_server=args.device_parameter_server,
                                          device_inference=args.device_inference,

--- a/paper_experiment_leduc_example_buf_500.py
+++ b/paper_experiment_leduc_example_buf_500.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
                                          ),
 
                                          DISTRIBUTED=False,
-                                         log_verbose=False,
+                                         log_verbose=True,
                                          device_training=args.device_training,
                                          device_parameter_server=args.device_parameter_server,
                                          device_inference=args.device_inference,

--- a/paper_experiment_leduc_exploitability.py
+++ b/paper_experiment_leduc_exploitability.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
                                          ),
 
                                          DISTRIBUTED=False,
-                                         log_verbose=False,
+                                         log_verbose=True,
                                          device_training=args.device_training,
                                          device_parameter_server=args.device_parameter_server,
                                          device_inference=args.device_inference,


### PR DESCRIPTION
## Summary
- Create SummaryWriter only when logging is enabled
- Turn on log_verbose in all example experiment scripts so TensorBoard receives scalars

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b70a96dd083309963a67da06381cd