### PR TITLE
Avoid removing existing TensorBoard logs and reuse experiment handles

### DIFF
--- a/DeepCFR/workers/chief/local.py
+++ b/DeepCFR/workers/chief/local.py
@@ -2,7 +2,6 @@ import copy
 import os
 import pickle
 import re
-import shutil
 from os.path import join as ospj
 
 import psutil
@@ -60,8 +59,7 @@ class Chief(_ChiefBase):
     def create_experiment(self, name):
         sanitized = re.sub(r"[^\w.-]", "_", name)
         log_dir = ospj(self._t_prof.path_log_storage, sanitized)
-        if os.path.exists(log_dir):
-            shutil.rmtree(log_dir)
+        os.makedirs(log_dir, exist_ok=True)
         writer = SummaryWriter(log_dir=log_dir)
         handle = self._next_writer_handle
         self._next_writer_handle += 1


### PR DESCRIPTION
## Summary
- Preserve existing log directories when creating experiments
- Initialize TensorBoard experiments once per player and reuse handles for advantage and average training

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cbc809d78833082ec3474198c4edb