### PR TITLE
Avoid allocating GPUs to CPU-only actors

### DIFF
--- a/DeepCFR/workers/driver/Driver.py
+++ b/DeepCFR/workers/driver/Driver.py
@@ -54,11 +54,18 @@ class Driver(DriverBase):
         gpu_workers = la_gpu_workers + ps_gpu_workers + eval_gpu_workers
         gpu_fraction = min(1.0, total_gpu / gpu_workers) if gpu_workers > 0 else 0
 
-        MaybeRay._default_num_gpus = gpu_fraction if eval_uses_gpu else 0
+        # Force CPU-only allocation for actors created by DriverBase (Chief and evaluators).
+        # These components do not require GPU resources and would otherwise reserve a
+        # fraction of the available GPUs when `eval_uses_gpu` is true.
+        MaybeRay._default_num_gpus = 0
 
         super().__init__(t_prof=t_prof, eval_methods=eval_methods, n_iterations=n_iterations,
                          iteration_to_import=iteration_to_import, name_to_import=name_to_import,
                          chief_cls=Chief, eval_agent_cls=EvalAgentDeepCFR)
+
+        # Restore the default so subsequent workers that do require GPU can opt in
+        # by explicitly requesting it when created.
+        MaybeRay._default_num_gpus = gpu_fraction if eval_uses_gpu else 0
 
         # Determine Ray's log directory and configure TensorBoard
         #


### PR DESCRIPTION
## Summary
- ensure DriverBase spawns Chief and evaluation helpers without reserving GPU resources
- reset MaybeRay's default GPU count before base initialisation and restore it afterwards so only explicit workers can request GPUs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e18307ef88330ab481ac139bcf948