### PR TITLE
Refactor device resolution in DeepCFR workers

### DIFF
--- a/DeepCFR/TrainingProfile.py
+++ b/DeepCFR/TrainingProfile.py
@@ -7,7 +7,6 @@ import re
 import shutil
 from datetime import datetime
 
-import torch
 from torch.utils.tensorboard import SummaryWriter
 from PokerRL.game import bet_sets
 from PokerRL.game.games import DiscretizedNLLeduc
@@ -20,13 +19,6 @@ from DeepCFR.EvalAgentDeepCFR import EvalAgentDeepCFR
 from DeepCFR.workers.la.AdvWrapper import AdvTrainingArgs
 from DeepCFR.workers.la.AvrgWrapper import AvrgTrainingArgs
 from utils.memory import estimate_batch_size
-
-
-def _resolve_device(dev):
-    """Translate special device strings."""
-    if isinstance(dev, str) and dev.lower() == "auto":
-        return "cuda" if torch.cuda.is_available() else "cpu"
-    return dev
 
 
 class TrainingProfile(TrainingProfileBase):
@@ -130,10 +122,6 @@ class TrainingProfile(TrainingProfileBase):
 
                  ):
         print(" ************************** Initing args for: ", name, "  **************************")
-
-        device_inference = _resolve_device(device_inference)
-        device_training = _resolve_device(device_training)
-        device_parameter_server = _resolve_device(device_parameter_server)
 
         if mini_batch_size_adv is None or mini_batch_size_avrg is None:
             est = estimate_batch_size()
@@ -289,8 +277,7 @@ class TrainingProfile(TrainingProfileBase):
             self.n_learner_actors = 1
         self.max_n_las_sync_simultaneously = max_n_las_sync_simultaneously
 
-        assert isinstance(device_parameter_server, str), "Please pass a string (either 'cpu' or 'cuda')!"
-        self.device_parameter_server = torch.device(device_parameter_server)
+        self.device_parameter_server = device_parameter_server
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/DeepCFR/utils/device.py
+++ b/DeepCFR/utils/device.py
@@ -1,0 +1,22 @@
+import torch
+
+
+def resolve_device(dev):
+    """Resolve a device string into a :class:`torch.device`.
+
+    Args:
+        dev (str or torch.device): Desired device specification such as
+            "cpu", "cuda", or "auto". If "auto" is given, the function
+            selects "cuda" when a GPU is available, otherwise "cpu".
+
+    Returns:
+        torch.device: The resolved device.
+    """
+    if isinstance(dev, torch.device):
+        return dev
+    if isinstance(dev, str):
+        dev = dev.lower()
+        if dev == "auto":
+            dev = "cuda" if torch.cuda.is_available() else "cpu"
+        return torch.device(dev)
+    raise TypeError("Device must be a string or torch.device")

--- a/DeepCFR/workers/chief/local.py
+++ b/DeepCFR/workers/chief/local.py
@@ -13,6 +13,7 @@ from DeepCFR.StrategyBuffer import StrategyBuffer
 from PokerRL.rl import rl_util
 from PokerRL.rl.base_cls.workers.ChiefBase import ChiefBase as _ChiefBase
 from PokerRL.util import file_util
+from DeepCFR.utils.device import resolve_device
 
 
 class Chief(_ChiefBase):
@@ -22,6 +23,7 @@ class Chief(_ChiefBase):
         self._ps_handles = None
         self._la_handles = None
         self._env_bldr = rl_util.get_env_builder(t_prof=t_prof)
+        self._device_inference = resolve_device(self._t_prof.device_inference)
 
         # SummaryWriter handles
         self._writers = {}
@@ -39,7 +41,7 @@ class Chief(_ChiefBase):
                                owner=p,
                                env_bldr=self._env_bldr,
                                max_size=None,
-                               device=self._t_prof.device_inference)
+                               device=self._device_inference)
                 for p in range(t_prof.n_seats)
             ]
 
@@ -149,10 +151,10 @@ class Chief(_ChiefBase):
     # Only applicable to SINGLE
     def add_new_iteration_strategy_model(self, owner, adv_net_state_dict, cfr_iter):
         iter_strat = IterationStrategy(t_prof=self._t_prof, env_bldr=self._env_bldr, owner=owner,
-                                         device=self._t_prof.device_inference, cfr_iter=cfr_iter)
+                                         device=self._device_inference, cfr_iter=cfr_iter)
 
         iter_strat.load_net_state_dict(
-            self._ray.state_dict_to_torch(adv_net_state_dict, device=self._t_prof.device_inference))
+            self._ray.state_dict_to_torch(adv_net_state_dict, device=self._device_inference))
         self._strategy_buffers[iter_strat.owner].add(iteration_strat=iter_strat)
 
         #  Store to disk

--- a/DeepCFR/workers/driver/Driver.py
+++ b/DeepCFR/workers/driver/Driver.py
@@ -13,6 +13,7 @@ import re
 import shutil
 from datetime import datetime
 from torch.utils.tensorboard import SummaryWriter
+from DeepCFR.utils.device import resolve_device
 
 
 class Driver(DriverBase):
@@ -44,9 +45,13 @@ class Driver(DriverBase):
 
         total_gpu = torch.cuda.device_count() if torch.cuda.is_available() else 0
 
-        la_uses_gpu = _is_cuda(t_prof.module_args["adv_training"].device_training) or _is_cuda(t_prof.device_inference)
-        ps_uses_gpu = _is_cuda(t_prof.device_parameter_server)
-        eval_uses_gpu = _is_cuda(t_prof.device_inference)
+        adv_device = resolve_device(t_prof.module_args["adv_training"].device_training)
+        inf_device = resolve_device(t_prof.device_inference)
+        ps_device = resolve_device(t_prof.device_parameter_server)
+
+        la_uses_gpu = _is_cuda(adv_device) or _is_cuda(inf_device)
+        ps_uses_gpu = _is_cuda(ps_device)
+        eval_uses_gpu = _is_cuda(inf_device)
 
         la_gpu_workers = t_prof.n_learner_actors if la_uses_gpu else 0
         ps_gpu_workers = t_prof.n_seats if ps_uses_gpu else 0

--- a/DeepCFR/workers/la/AdvWrapper.py
+++ b/DeepCFR/workers/la/AdvWrapper.py
@@ -3,11 +3,13 @@ import torch
 from PokerRL.rl.neural.DuelingQNet import DuelingQNet
 from PokerRL.rl.neural.NetWrapperBase import NetWrapperArgsBase as _NetWrapperArgsBase
 from PokerRL.rl.neural.NetWrapperBase import NetWrapperBase as _NetWrapperBase
+from DeepCFR.utils.device import resolve_device
 
 
 class AdvWrapper(_NetWrapperBase):
 
     def __init__(self, env_bldr, adv_training_args, owner, device):
+        device = resolve_device(device)
         super().__init__(
             net=DuelingQNet(env_bldr=env_bldr, q_args=adv_training_args.adv_net_args, device=device),
             env_bldr=env_bldr,

--- a/DeepCFR/workers/la/AvrgWrapper.py
+++ b/DeepCFR/workers/la/AvrgWrapper.py
@@ -5,11 +5,13 @@ from PokerRL.rl import rl_util
 from PokerRL.rl.neural.AvrgStrategyNet import AvrgStrategyNet
 from PokerRL.rl.neural.NetWrapperBase import NetWrapperArgsBase as _NetWrapperArgsBase
 from PokerRL.rl.neural.NetWrapperBase import NetWrapperBase as _NetWrapperBase
+from DeepCFR.utils.device import resolve_device
 
 
 class AvrgWrapper(_NetWrapperBase):
 
     def __init__(self, owner, env_bldr, avrg_training_args, device):
+        device = resolve_device(device)
         super().__init__(
             net=AvrgStrategyNet(avrg_net_args=avrg_training_args.avrg_net_args, env_bldr=env_bldr, device=device),
             env_bldr=env_bldr,

--- a/DeepCFR/workers/ps/local.py
+++ b/DeepCFR/workers/ps/local.py
@@ -9,6 +9,7 @@ from PokerRL.rl import rl_util
 from PokerRL.rl.base_cls.workers.ParameterServerBase import ParameterServerBase
 from PokerRL.rl.neural.AvrgStrategyNet import AvrgStrategyNet
 from PokerRL.rl.neural.DuelingQNet import DuelingQNet
+from DeepCFR.utils.device import resolve_device
 
 
 class ParameterServer(ParameterServerBase):
@@ -17,6 +18,7 @@ class ParameterServer(ParameterServerBase):
         super().__init__(t_prof=t_prof, chief_handle=chief_handle)
 
         self.owner = owner
+        self._device = resolve_device(t_prof.device_parameter_server)
         self._adv_args = t_prof.module_args["adv_training"]
 
         self._adv_net = self._get_new_adv_net()


### PR DESCRIPTION
## Summary
- keep device strings in `TrainingProfile` without resolving them
- add `DeepCFR.utils.device.resolve_device` for runtime torch device resolution
- resolve devices inside workers and wrappers (`LearnerActor`, `ParameterServer`, `Chief`, etc.)

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a75ee61a0c833098f894a7103d8049