### PR TITLE
Free TensorBoard writer handles after closing

### DIFF
--- a/DeepCFR/workers/chief/local.py
+++ b/DeepCFR/workers/chief/local.py
@@ -82,11 +82,12 @@ class Chief(_ChiefBase):
                 pass
 
     def close_tb_writers(self):
-        for w in self._writers.values():
+        for key in list(self._writers.keys()):
             try:
-                w.close()
+                self._writers[key].close()
             except Exception:
                 pass
+            del self._writers[key]
 
     # ____________________________________________________ Strategy ____________________________________________________
     def pull_current_eval_strategy(self, last_iteration_receiver_has):


### PR DESCRIPTION
## Summary
- clear and remove TensorBoard writers when closing to free resources

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9f0a2291c833092e289b170205c36