### PR TITLE
Centralize TensorBoard setup in Driver

### DIFF
--- a/DeepCFR/TrainingProfile.py
+++ b/DeepCFR/TrainingProfile.py
@@ -2,12 +2,7 @@
 
 
 import copy
-import os
-import re
-import shutil
-from datetime import datetime
 
-from torch.utils.tensorboard import SummaryWriter
 from PokerRL.game import bet_sets
 from PokerRL.game.games import DiscretizedNLLeduc
 from PokerRL.game.wrappers import HistoryEnvBuilder, FlatLimitPokerEnvBuilder
@@ -231,25 +226,9 @@ class TrainingProfile(TrainingProfileBase):
                 "lbr": lbr_args,
                 "rlbr": rl_br_args,
                 "h2h": h2h_args,
-            } 
+            }
         )
-
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        sanitized_name = re.sub(r"[^\w.-]", "_", str(self.name))
-        run_root = os.path.join(self._data_path, "tensorboard", sanitized_name)
-        if os.path.exists(run_root):
-            archive_root = os.path.join(run_root, "archive")
-            os.makedirs(archive_root, exist_ok=True)
-            for entry in os.listdir(run_root):
-                full = os.path.join(run_root, entry)
-                if full == archive_root:
-                    continue
-                if os.path.isdir(full):
-                    shutil.move(full, os.path.join(archive_root, entry))
-        self.path_log_storage = os.path.join(run_root, timestamp)
-        if os.path.exists(self.path_log_storage):
-            shutil.rmtree(self.path_log_storage)
-        os.makedirs(self.path_log_storage, exist_ok=True)
+        self.path_log_storage = None
 
         self.nn_type = nn_type
         self.online = online
@@ -257,10 +236,6 @@ class TrainingProfile(TrainingProfileBase):
         self.iter_weighting_exponent = iter_weighting_exponent
         self.sampler = sampler
         self.n_actions_traverser_samples = n_actions_traverser_samples
-
-        self.tb_writer = SummaryWriter(log_dir=self.path_log_storage, flush_secs=5, max_queue=10) if self.log_verbose else None
-        if self.log_verbose:
-            print(f"TensorBoard logs will be written to {self.path_log_storage}")
 
         self.mini_batch_size_adv = mini_batch_size_adv
         self.mini_batch_size_avrg = mini_batch_size_avrg
@@ -286,6 +261,4 @@ class TrainingProfile(TrainingProfileBase):
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        self.tb_writer = SummaryWriter(log_dir=self.path_log_storage, flush_secs=5, max_queue=10) if self.log_verbose else None
-        if self.log_verbose:
-            print(f"TensorBoard logs will be written to {self.path_log_storage}")
+        self.tb_writer = None


### PR DESCRIPTION
## Summary
- Delegate TensorBoard directory and SummaryWriter setup to Driver
- Remove duplicated TensorBoard initialization from TrainingProfile
- Ensure TrainingProfile serialization leaves `tb_writer` unset

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9f27b125883309062c3054d6e7916