### PR TITLE
Handle undersized batches in advantage buffer

### DIFF
--- a/DeepCFR/workers/la/AdvWrapper.py
+++ b/DeepCFR/workers/la/AdvWrapper.py
@@ -25,12 +25,15 @@ class AdvWrapper(_NetWrapperBase):
             return self._net(pub_obses=pub_obses, range_idxs=range_idxs, legal_action_masks=legal_action_mask)
 
     def _mini_batch_loop(self, buffer, grad_mngr):
+        sample = buffer.sample(device=self.device, batch_size=self._batch_size)
+        if sample is None:
+            return
         batch_pub_obs, \
         batch_range_idxs, \
         batch_legal_action_masks, \
         batch_adv, \
         batch_loss_weight, \
-            = buffer.sample(device=self.device, batch_size=self._batch_size)
+            = sample
 
         # [batch_size, n_actions]
         adv_pred = self._net(pub_obses=batch_pub_obs,

--- a/DeepCFR/workers/la/buffers/AdvReservoirBuffer.py
+++ b/DeepCFR/workers/la/buffers/AdvReservoirBuffer.py
@@ -32,6 +32,9 @@ class AdvReservoirBuffer(_ResBufBase):
         self.n_entries_seen += 1
 
     def sample(self, batch_size, device):
+        if self.size == 0 or self.size < batch_size:
+            return None
+
         indices = torch.randint(0, self.size, (batch_size,), dtype=torch.long, device=self.device)
 
         if self._nn_type == "recurrent":

--- a/DeepCFR/workers/la/local.py
+++ b/DeepCFR/workers/la/local.py
@@ -279,12 +279,16 @@ class LearnerActor(WorkerBase):
         return self._avrg_wrappers[p_id].loss_last_batch
 
     def get_adv_grads(self, p_id):
-        return self._ray.grads_to_numpy(
-            self._adv_wrappers[p_id].get_grads_one_batch_from_buffer(buffer=self._adv_buffers[p_id]))
+        grads = self._adv_wrappers[p_id].get_grads_one_batch_from_buffer(buffer=self._adv_buffers[p_id])
+        if grads is None:
+            return None
+        return self._ray.grads_to_numpy(grads)
 
     def get_avrg_grads(self, p_id):
-        return self._ray.grads_to_numpy(
-            self._avrg_wrappers[p_id].get_grads_one_batch_from_buffer(buffer=self._avrg_buffers[p_id]))
+        grads = self._avrg_wrappers[p_id].get_grads_one_batch_from_buffer(buffer=self._avrg_buffers[p_id])
+        if grads is None:
+            return None
+        return self._ray.grads_to_numpy(grads)
 
     def checkpoint(self, curr_step):
         for p_id in range(self._env_bldr.N_SEATS):


### PR DESCRIPTION
## Summary
- Guard advantage buffer sampling against undersized batches
- Skip mini-batch and gradient computations when no batch is available
- Safely return None for gradient requests without enough data

## Testing
- `pytest`
- `python -m py_compile DeepCFR/workers/la/buffers/AdvReservoirBuffer.py DeepCFR/workers/la/AdvWrapper.py DeepCFR/workers/la/local.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa0303f0d883308bcc0f84222fe223