### PR TITLE
Handle missing losses in gradient collection

### DIFF
--- a/DeepCFR/workers/driver/_HighLevelAlgo.py
+++ b/DeepCFR/workers/driver/_HighLevelAlgo.py
@@ -220,7 +220,7 @@ class HighLevelAlgo(_HighLevelAlgoBase):
         losses = [loss for loss in losses if loss is not None]
 
         if not losses:
-            return grads, None
+            return grads_refs, None
 
         averaged_loss = sum(losses) / float(len(losses))
 


### PR DESCRIPTION
## Summary
- Prevent undefined variable when advantage losses are absent
- Confirm `_train_adv` skips gradient updates when no losses are reported

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa0af5534883309c6221024a7069e2