### PR TITLE
Handle learner actor failures gracefully

### DIFF
--- a/DeepCFR/workers/driver/Driver.py
+++ b/DeepCFR/workers/driver/Driver.py
@@ -350,6 +350,8 @@ class Driver(DriverBase):
                 # Checkpoint
                 # """"""""""""""""
                 self.periodically_checkpoint()
+        except RuntimeError as e:
+            print(f"Training stopped: {e}")
         finally:
             try:
                 self._ray.wait([self._ray.remote(self.chief_handle.flush_tb_writers)])

--- a/DeepCFR/workers/driver/_HighLevelAlgo.py
+++ b/DeepCFR/workers/driver/_HighLevelAlgo.py
@@ -69,6 +69,11 @@ class HighLevelAlgo(_HighLevelAlgoBase):
                 print(f"Parameter server {actor_hex} failed. Removing handle.")
                 self._ps_handles[i] = None
 
+        if not self._la_handles:
+            msg = "No learner actors remaining. Terminating training."
+            print(msg)
+            raise RuntimeError(msg)
+
     def init(self):
         # """"""""""""""""""""""
         # Deep CFR


### PR DESCRIPTION
## Summary
- fail fast when all learner actors have crashed
- stop driver training loop when no learners remain

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa0af65360833098a931434bb47f3d