### PR TITLE
Use actor names for worker initialization

### DIFF
--- a/DeepCFR/workers/la/dist.py
+++ b/DeepCFR/workers/la/dist.py
@@ -5,7 +5,7 @@ from DeepCFR.workers.la.local import LearnerActor as LocalLearnerActor
 
 @ray.remote
 class LearnerActor(LocalLearnerActor):
-    """Distributed LearnerActor inheriting profiling from LocalLearnerActor."""
+    """Distributed ``LearnerActor`` that rebuilds the Chief handle from a name."""
 
-    def __init__(self, t_prof, worker_id, chief_handle):
-        super().__init__(t_prof=t_prof, worker_id=worker_id, chief_handle=chief_handle)
+    def __init__(self, t_prof, worker_id, chief_ref):
+        super().__init__(t_prof=t_prof, worker_id=worker_id, chief_ref=chief_ref)

--- a/DeepCFR/workers/ps/dist.py
+++ b/DeepCFR/workers/ps/dist.py
@@ -6,5 +6,5 @@ from DeepCFR.workers.ps.local import ParameterServer as _LocalParameterServer
 @ray.remote
 class ParameterServer(_LocalParameterServer):
 
-    def __init__(self, t_prof, owner, chief_handle):
-        super().__init__(t_prof=t_prof, owner=owner, chief_handle=chief_handle)
+    def __init__(self, t_prof, owner, chief_ref):
+        super().__init__(t_prof=t_prof, owner=owner, chief_ref=chief_ref)

--- a/DeepCFR/workers/ps/local.py
+++ b/DeepCFR/workers/ps/local.py
@@ -15,7 +15,16 @@ from DeepCFR.utils.device import resolve_device
 
 class ParameterServer(ParameterServerBase):
 
-    def __init__(self, t_prof, owner, chief_handle):
+    def __init__(self, t_prof, owner, chief_ref):
+        """Parameter server that may reconstruct the chief actor by name."""
+
+        if isinstance(chief_ref, str):
+            import ray
+
+            chief_handle = ray.get_actor(chief_ref)
+        else:
+            chief_handle = chief_ref
+
         super().__init__(t_prof=t_prof, chief_handle=chief_handle)
 
         self.owner = owner


### PR DESCRIPTION
## Summary
- name every Ray worker when created and expose name via handle
- pass chief actor name to learner actors and parameter servers so they reconstruct the handle
- adjust distributed wrappers to forward the primitive chief reference

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b096e65970833092ba8478ab687ffe