### PR TITLE
fix: support Ray ActorClass naming

### DIFF
--- a/DeepCFR/__init__.py
+++ b/DeepCFR/__init__.py
@@ -92,7 +92,13 @@ try:  # pragma: no cover - best effort patching
         if name is None:
             import uuid
 
-            name = f"{cls.__name__}_{uuid.uuid4().hex}"
+            cls_name = getattr(cls, "__name__", None)
+            if cls_name is None:
+                cls_name = getattr(getattr(cls, "__ray_metadata__", None), "class_name", None)
+            if cls_name is None:
+                cls_name = cls.__class__.__name__
+
+            name = f"{cls_name}_{uuid.uuid4().hex}"
 
         if self.runs_distributed:
             if num_cpus is None:


### PR DESCRIPTION
## Summary
- handle Ray ActorClass without `__name__` when creating workers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc75b28c83309e9af5de42f25b9e