### PR TITLE
Force Ray to spawn worker processes

### DIFF
--- a/DeepCFR/__init__.py
+++ b/DeepCFR/__init__.py
@@ -4,6 +4,24 @@ __all__ = []
 __version__ = "0.1.0"
 
 # ---------------------------------------------------------------------------
+# Multiprocessing start method
+# ---------------------------------------------------------------------------
+#
+# Ray defaults to forking worker processes which is unsafe once CUDA has been
+# initialised in the parent process.  To avoid ``SIGABRT`` crashes stemming from
+# a forked CUDA runtime, force Python's multiprocessing start method to ``spawn``
+# and instruct Ray to do the same via environment variable.  These statements
+# must run before importing Ray.
+import multiprocessing as _mp
+import os as _os
+
+_os.environ.setdefault("RAY_START_METHOD", "spawn")
+try:  # pragma: no cover - start method can be set only once
+    _mp.set_start_method("spawn", force=True)
+except RuntimeError:
+    pass
+
+# ---------------------------------------------------------------------------
 # Compatibility patch for Ray >=2.0
 # ---------------------------------------------------------------------------
 #


### PR DESCRIPTION
## Summary
- enforce spawn start method for multiprocessing and Ray to avoid SIGABRT crashes from forking a CUDA runtime

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b079cd75c083308bfd0f16f8317c68