### PR TITLE
Specify SciPy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy==2.3.2
+scipy==1.16.1
 psutil==7.0.0
 ray[default]==2.48.0
 torch==2.8.0


### PR DESCRIPTION
## Summary
- Add pinned SciPy 1.16.1 requirement to match PokerRL's dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb89a752cc8330a1ae23f9db761ed2