### PR TITLE
Fix reach weighting broadcast in get_a_probs

### DIFF
--- a/DeepCFR/EvalAgentDeepCFR.py
+++ b/DeepCFR/EvalAgentDeepCFR.py
@@ -219,10 +219,11 @@ class EvalAgentDeepCFR(_EvalAgentBase):
                 # """"""""""""""""""""""
                 # Weighted by Reach
                 # """"""""""""""""""""""
+                # Expand reach weights to shape [n_models, 1] so they broadcast over action probabilities
                 a_probs_each_model *= np.expand_dims(self._get_reach_for_each_model(
                     p_id_acting=p_id_acting,
                     range_idx=range_idx,
-                ), axis=2)
+                ), axis=1)
 
                 # """"""""""""""""""""""
                 # Normalize


### PR DESCRIPTION
## Summary
- Fix shape expansion for per-model reach weights in `get_a_probs`
- Ensure reach weights broadcast correctly over action probabilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb8b6e160c833092757d503fa54b04